### PR TITLE
fusion ADD-In Profile

### DIFF
--- a/profiles/osxFusionAddIn/Info.plist
+++ b/profiles/osxFusionAddIn/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleGetInfoString</key>
+	<string>{{AppDescription}}</string>
+	<key>CFBundleIdentifier</key>
+	<string>{{AppNameSpace}}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>{{AppVersion}}</string>
+	<key>IFMajorVersion</key>
+	<integer>1</integer>
+	<key>IFMinorVersion</key>
+	<integer>0</integer>
+	<key>IFPkgFlagAllowBackRev</key>
+	<false/>
+	<key>IFPkgFlagAuthorizationAction</key>
+	<string>AdminAuthorization</string>
+	<key>IFPkgFlagBackgroundAlignment</key>
+	<string>topleft</string>
+	<key>IFPkgFlagBackgroundScaling</key>
+	<string>none</string>
+	<key>IFPkgFlagDefaultLocation</key>
+	<string>/</string>
+	<key>IFPkgFlagFollowLinks</key>
+	<true/>
+	<key>IFPkgFlagInstallFat</key>
+	<false/>
+	<key>IFPkgFlagIsRequired</key>
+	<false/>
+	<key>IFPkgFlagOverwritePermissions</key>
+	<false/>
+	<key>IFPkgFlagRelocatable</key>
+	<false/>
+	<key>IFPkgFlagRestartAction</key>
+	<string>NoRestart</string>
+	<key>IFPkgFlagRootVolumeOnly</key>
+	<false/>
+	<key>IFPkgFlagUpdateInstalledLanguages</key>
+	<false/>
+	<key>IFPkgFormatVersion</key>
+	<real>0.1000000014901161</real>
+</dict>
+</plist>

--- a/profiles/osxFusionAddIn/Resources/License.rtf
+++ b/profiles/osxFusionAddIn/Resources/License.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1138\cocoasubrtf510
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+\margl1440\margr1440\vieww9000\viewh8400\viewkind0
+\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural
+{\field{\*\fldinst{HYPERLINK "http://apps.exchange.autodesk.com/en/eula"}}{\fldrslt 
+\f0\fs24 \cf0 View Store Terms and Conditions}}
+\f0\fs24 \
+\
+}

--- a/profiles/osxFusionAddIn/Resources/Welcome.rtf
+++ b/profiles/osxFusionAddIn/Resources/Welcome.rtf
@@ -1,0 +1,10 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1138\cocoasubrtf510
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\froman\fcharset0 TimesNewRomanPSMT;}
+{\colortbl;\red255\green255\blue255;}
+\margl1440\margr1440\vieww12840\viewh16440\viewkind1
+\deftab720
+\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardeftab720\ri0
+
+\f0\fs24 \cf0 Welcome to the \{\{AppDescription\}\} Installer
+\f1\fs22 \
+}

--- a/profiles/osxFusionAddIn/Scripts/preinstall
+++ b/profiles/osxFusionAddIn/Scripts/preinstall
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+echo Using osxFusionAppIn
+
+previous_bundle_dir="$HOME/Library/Containers/com.autodesk.mas.fusion360/Data/Library/Application Support/Autodesk/ApplicationPlugins"
+echo previous bundle dir = $previous_bundle_dir
+
+previous_bundle_path="$previous_bundle_dir/{{BUNDLE}}"
+echo previous bundle path = $previous_bundle_path
+
+if [ -d "$previous_bundle_path" ]; then
+  echo deleting directory "$previous_bundle_path"
+  rm -rf "$previous_bundle_path"
+else
+  echo "${previous_bundle_path} not found. Can not delete."
+fi
+
+previous_bundle_link_dir="$HOME/Library/Application Support/Autodesk/ApplicationPlugins"
+echo previous bundle link dir = $previous_bundle_link_dir
+
+previous_bundle_path_link="$previous_bundle_link_dir/{{BUNDLE}}"
+echo previous bundle path link = $previous_bundle_path_link
+
+if [ -d "$previous_bundle_path_link" ]; then
+  echo deleting directory "$previous_bundle_path_link"
+  rm -rf "$previous_bundle_path_link"
+else
+  echo "${previous_bundle_path_link} not found. Can not delete."
+fi
+
+
+
+
+echo Done
+exit 0

--- a/profiles/osxFusionAddIn/build-osx-sub
+++ b/profiles/osxFusionAddIn/build-osx-sub
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+chmod -R 777 ./temp
+grep -lUIr "\r" ./temp | while read line; do echo "DOS->UNIX - $line"; $FLIP -u $line; done
+
+pkgbuild \
+	--component "./temp/root/$AppName" \
+	--scripts ./temp/Scripts \
+	--install-location /Library/Application\ Support/Autodesk/ApplicationPlugins \
+	"./temp/$AppName.pkg"
+
+if [ ! $? -eq 0 ]; then
+	echo "pkgbuild --component ... error"
+else
+	productbuild \
+		--distribution ./temp/distribution.xml \
+		--resources ./temp/Resources/ \
+		--package-path ./temp \
+		"./output/$AppName.pkg"
+
+	if [ ! $? -eq 0 ]; then
+		echo "productbuild --distribution ... error"
+	fi
+fi

--- a/profiles/osxFusionAddIn/distribution.xml
+++ b/profiles/osxFusionAddIn/distribution.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<installer-gui-script minSpecVersion="1">
+    <title>{{AppName}}</title>
+    <organization>com.autodesk</organization>
+    <domains enable_currentUserHome="true"
+             enable_localSystem ="false" />
+    <options
+             customize="never"
+             require-scripts="false" />
+    <!-- Define documents displayed at various steps -->
+    <welcome file="Welcome.rtf" mime-type="application/rtf" />
+    <license file="License.rtf" mime-type="application/rtf" />
+    <!-- List all component packages -->
+    <pkg-ref id="{{AppNameSpace}}"
+             version="{{AppVersion}}"
+             auth="root">{{INSTALLER-PKG}}</pkg-ref>
+    <!-- List them again here. They can now be organized
+         as a hierarchy if you want. -->
+    <choices-outline>
+        <line choice="install" />
+    </choices-outline>
+    <!-- Define each choice above -->
+    <choice
+        id="install"
+        visible="false"
+        title="{{AppName}}"
+        description="{{AppDescription}}"
+        start_selected="true">
+      <pkg-ref id="{{AppNameSpace}}" />
+    </choice>
+</installer-gui-script>
+

--- a/profiles/osxFusionAddIn/manifest.manifest
+++ b/profiles/osxFusionAddIn/manifest.manifest
@@ -1,0 +1,13 @@
+{
+	"autodeskProduct": "{{AutodeskProduct}}",
+	"type": "addin",
+	"id": "{{UpgradeCodeLessBackets}}",
+	"author": "{{AuthorPublisher}}",
+	"description": {
+		"":	"{{AppDescription}}"
+	},
+	"version": "{{AppVersion}}",
+	"runOnStartup": true,
+	"supportedOS": "{{manifestOS}}",
+	"autodeskLibraries": ["application", "dashboard", "geometry", "materials", "userInterface", "utilities", "bRep", "components", "construction", "features", "fusion", "meshBody", "meshData", "sketch", "tSpline"]
+}

--- a/scripts/createPluginInstaller.py
+++ b/scripts/createPluginInstaller.py
@@ -254,6 +254,8 @@ def createMacInstaller ():
 	RenderRtfFile (cmdLineArgs ['template'] + '/Resources/License.rtf', resDir + '/License.rtf')
 	if os.path.isfile (cmdLineArgs ['template'] + '/Scripts/postinstall'):
 		RenderFile (cmdLineArgs ['template'] + '/Scripts/postinstall', scriptsDir + '/postinstall')
+	if os.path.isfile (cmdLineArgs ['template'] + '/Scripts/preinstall'):
+		RenderFile (cmdLineArgs ['template'] + '/Scripts/preinstall', scriptsDir + '/preinstall')
 	if os.path.isfile (cmdLineArgs ['template'] + '/distribution.xml') and not os.path.isfile (moduleDir + '/distribution.xml'):
 		RenderFile (cmdLineArgs ['template'] + '/distribution.xml', tempdir + '/distribution.xml')
 	if os.path.isfile (cmdLineArgs ['template'] + '/InstallerSections.plist') and not os.path.isfile (moduleDir + '/InstallerSections.plist'):


### PR DESCRIPTION
added New profile to fusion ADD-In apps

- It installs Addin APP at user's /Library/Application Support/Autodesk/ApplicationPlugins
- Added support for preinstall script to do some cleanup works like deleting old plugin from mac store location
- modified distributionxml file **enable_localSystem ="false"** to always install at users's home location.
